### PR TITLE
Persist state better after login redirect

### DIFF
--- a/Dev/HealthCheck.DevTest.NetCore_3.1/Controllers/DevController.cs
+++ b/Dev/HealthCheck.DevTest.NetCore_3.1/Controllers/DevController.cs
@@ -58,6 +58,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace HealthCheck.DevTest.NetCore_3._1.Controllers
 {
@@ -266,6 +267,7 @@ namespace HealthCheck.DevTest.NetCore_3._1.Controllers
             config.ShowFailedModuleLoadStackTrace = new Maybe<RuntimeTestAccessRole>(RuntimeTestAccessRole.WebAdmins);
             config.PingAccess = new Maybe<RuntimeTestAccessRole>(RuntimeTestAccessRole.API);
             config.RedirectTargetOnNoAccess = "/no-access";
+            //config.RedirectTargetOnNoAccessUsingRequest = (r, q) => $"/DummyLoginRedirect?r={HttpUtility.UrlEncode($"/?{q}")}";
             config.IntegratedLoginConfig = new HCIntegratedLoginConfig
             {
                 IntegratedLoginEndpoint = "/HCLogin/login",

--- a/Dev/HealthCheck.DevTest.NetCore_3.1/Controllers/DummyLoginRedirectController.cs
+++ b/Dev/HealthCheck.DevTest.NetCore_3.1/Controllers/DummyLoginRedirectController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace HealthCheck.DevTest.NetCore_3._1.Controllers
+{
+    [Route("[controller]")]
+    public class DummyLoginRedirectController : Controller
+    {
+        [HttpGet]
+        public IActionResult Index([FromQuery] string r)
+        {
+            System.Diagnostics.Debug.WriteLine($"Redirect: {r}");
+            return Redirect(r);
+        }
+    }
+}

--- a/Dev/HealthCheck.DevTest.NetFramework/Controllers/DevController.cs
+++ b/Dev/HealthCheck.DevTest.NetFramework/Controllers/DevController.cs
@@ -305,7 +305,8 @@ namespace HealthCheck.DevTest.Controllers
 
             config.ShowFailedModuleLoadStackTrace = new Maybe<RuntimeTestAccessRole>(RuntimeTestAccessRole.WebAdmins);
             config.PingAccess = new Maybe<RuntimeTestAccessRole>(RuntimeTestAccessRole.API);
-            config.RedirectTargetOnNoAccess = "/no-access";
+            //config.RedirectTargetOnNoAccess = "/no-access";
+            config.RedirectTargetOnNoAccessUsingRequest = (r, q) => $"/DummyLoginRedirect?r={HttpUtility.UrlEncode($"/?{q}")}";
             config.IntegratedLoginConfig = new HCIntegratedLoginConfig
             {
                 IntegratedLoginEndpoint = "/hclogin/login",

--- a/HealthCheck.Frontend/src/components/HealthCheckPageComponent.vue
+++ b/HealthCheck.Frontend/src/components/HealthCheckPageComponent.vue
@@ -61,6 +61,8 @@ import ModuleConfig from "../models/Common/ModuleConfig";
 import BackendInputComponent from "./Common/Inputs/BackendInputs/BackendInputComponent.vue";
 import HealthCheckProfileDialogComponent from 'components/profile/HealthCheckProfileDialogComponent.vue';
 import { HCFrontEndOptions } from "generated/Models/WebUI/HCFrontEndOptions";
+import { Route } from "vue-router";
+import UrlUtils from "util/UrlUtils";
 
 @Component({
     components: {
@@ -84,6 +86,7 @@ export default class HealthCheckPageComponent extends Vue {
     {
         this.setInitialPage();
         this.bindRootEvents();
+        this.$router.afterEach((t, f) => this.onRouteChanged(t, f));
     }
 
     ////////////////
@@ -207,6 +210,12 @@ export default class HealthCheckPageComponent extends Vue {
     setInitialPage(): void
     {
         // X:ToDo: set based on prioritized order if nothing active.
+        let queryState = UrlUtils.GetQueryStringParameter('h');
+        if (queryState)
+        {
+            queryState = queryState.replace('#', '');
+            this.$router.push(queryState);
+        }
         
         let anyRouteActive = this.$route.matched.length > 0;
         if (!anyRouteActive && this.validModuleConfigs.length > 0)
@@ -224,6 +233,10 @@ export default class HealthCheckPageComponent extends Vue {
     /////////////////////
     onSideMenuToggleButtonClicked(): void {
         this.$store.commit('toggleMenuExpanded');
+    }
+
+    onRouteChanged(to: Route, from: Route): void {
+        UrlUtils.SetQueryStringParameter('h', window.location.hash)
     }
 }
 </script>

--- a/HealthCheck.Frontend/src/util/UrlUtils.ts
+++ b/HealthCheck.Frontend/src/util/UrlUtils.ts
@@ -9,6 +9,12 @@ export default class UrlUtils
         return value.replace(/ /g, '-').replace('/', '-');
     }
 
+    static SetQueryStringParameter(key: string, value: string): void {
+        const params = new URLSearchParams(location.search);
+        params.set(key, value);
+        window.history.replaceState({}, '', `${location.pathname}?${params.toString()}${location.hash}`);
+    }
+
     static GetQueryStringParameter(key: string, fallbackValue: string | null = null): string | null
     {
         let params = new URLSearchParams(location.search);

--- a/HealthCheck.WebUI/Abstractions/HealthCheckControllerBase.NetCore.cs
+++ b/HealthCheck.WebUI/Abstractions/HealthCheckControllerBase.NetCore.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -110,7 +111,8 @@ namespace HealthCheck.WebUI.Abstractions
                     return CreateIntegratedLoginViewResult();
                 }
 
-                var redirectTarget = Helper.AccessConfig.RedirectTargetOnNoAccessUsingRequest?.Invoke(Request);
+                var queryStringState = "h=" + System.Web.HttpUtility.UrlEncode($"{Request.Query?["h"].FirstOrDefault() ?? ""}");
+                var redirectTarget = Helper.AccessConfig.RedirectTargetOnNoAccessUsingRequest?.Invoke(Request, queryStringState);
                 if (!string.IsNullOrWhiteSpace(redirectTarget))
                 {
                     return Redirect(redirectTarget);

--- a/HealthCheck.WebUI/Abstractions/HealthCheckControllerBase.NetFramework.cs
+++ b/HealthCheck.WebUI/Abstractions/HealthCheckControllerBase.NetFramework.cs
@@ -108,8 +108,9 @@ namespace HealthCheck.WebUI.Abstractions
                 {
                     return CreateIntegratedLoginViewResult();
                 }
-
-                var redirectTarget = Helper.AccessConfig.RedirectTargetOnNoAccessUsingRequest?.Invoke(Request);
+                
+                var queryStringState = "h=" + System.Web.HttpUtility.UrlEncode($"{Request.QueryString?["h"] ?? ""}");
+                var redirectTarget = Helper.AccessConfig.RedirectTargetOnNoAccessUsingRequest?.Invoke(Request, queryStringState);
                 if (!string.IsNullOrWhiteSpace(redirectTarget))
                 {
                     return Redirect(redirectTarget);

--- a/HealthCheck.WebUI/Models/AccessConfig.cs
+++ b/HealthCheck.WebUI/Models/AccessConfig.cs
@@ -54,19 +54,23 @@ namespace HealthCheck.WebUI.Models
 #if NETFULL
         /// <summary>
         /// Redirect url if the request does not have access to any of the content.
+        /// <para>Input string parameter is the url encoded querystring part that can be used to redirect back to the current state.</para>
+        /// <para>Example: <c>(r, q) =&gt; "/login?return={HttpUtility.UrlEncode($"/healthcheck?{q}")}"</c></para>
         /// <para>If not set a 404 will be returned.</para>
         /// <para>Takes priority over <see cref="RedirectTargetOnNoAccess"/>.</para>
         /// </summary>
-        public Func<HttpRequestBase, string> RedirectTargetOnNoAccessUsingRequest { get; set; }
+        public Func<HttpRequestBase, string, string> RedirectTargetOnNoAccessUsingRequest { get; set; }
 #endif
 
 #if NETCORE
         /// <summary>
         /// Redirect url if the request does not have access to any of the content.
+        /// <para>Input string parameter is the url encoded querystring part that can be used to redirect back to the current state.</para>
+        /// <para>Example: <c>(r, q) =&gt; "/login?return={HttpUtility.UrlEncode($"/healthcheck?{q}")}"</c></para>
         /// <para>If not set a 404 will be returned.</para>
         /// <para>Takes priority over <see cref="RedirectTargetOnNoAccess"/>.</para>
         /// </summary>
-        public Func<HttpRequest, string> RedirectTargetOnNoAccessUsingRequest { get; set; }
+        public Func<HttpRequest, string, string> RedirectTargetOnNoAccessUsingRequest { get; set; }
 #endif
 
         internal List<ModuleAccessData<TAccessRole>> RoleModuleAccessLevels { get; set; }


### PR DESCRIPTION
Update a querystring parameter on route change, and use it to set state after login redirect.